### PR TITLE
убрать требуемый движок

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,5 @@
     "circular-dependency-plugin": "5.2.0",
     "clean-webpack-plugin": "3.0.0",
     "duplicate-package-checker-webpack-plugin": "3.0.0"
-  },
-  "engines": {
-    "node": "8.15"
   }
 }


### PR DESCRIPTION
если обновить node, который сейчас текущий 14, то зависимости не установятся, проект не соберется. 
Убираем версию и всё нормально устанавливается.